### PR TITLE
disable jmeter with config property, enabled by default

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -15,7 +15,8 @@ config :perf_analyzer,
     dataset: :none,
     separator: ","
   },
-  distributed: :none
+  distributed: :none,
+  jmeter_report: true
 
 config :logger,
   level: :info

--- a/config/performance.exs
+++ b/config/performance.exs
@@ -5,19 +5,20 @@ config :perf_analyzer,
   request: %{
     method: "GET",
     headers: [{"Content-Type", "application/json"}],
-    body: fn item ->
+    body: fn _item ->
       ~s/'{"data":  #{Enum.random(1..10)},"key": 1}}}'/
     end
   },
   execution: %{
     steps: 5,
     increment: 1,
-    duration: 1000,
+    duration: 5000,
     constant_load: false,
     dataset: :none,
     separator: ","
   },
-  distributed: :none
+  distributed: :none,
+  jmeter_report: true
 
 config :logger,
   level: :info

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -15,7 +15,8 @@ config :perf_analyzer,
     dataset: :none,
     separator: ","
   },
-  distributed: :none
+  distributed: :none,
+  jmeter_report: true
 
 config :logger,
   level: :info

--- a/config/test.exs
+++ b/config/test.exs
@@ -30,7 +30,8 @@ config :perf_analyzer,
     dataset: :none,
     separator: ","
   },
-  distributed: :none
+  distributed: :none,
+  jmeter_report: true
 
 config :logger,
   level: :info

--- a/lib/perf/application.ex
+++ b/lib/perf/application.ex
@@ -24,6 +24,8 @@ defmodule Perf.Application do
       query: query,
     } = ConfParser.parse(url)
 
+    IO.puts "JMeter Report enabled: #{Application.get_env(:perf_analyzer, :jmeter_report, true)}"
+
     connection_conf = {scheme, host, port}
 
     distributed = Application.fetch_env!(:perf_analyzer, :distributed)

--- a/lib/perf/metrics_collector.ex
+++ b/lib/perf/metrics_collector.ex
@@ -3,7 +3,7 @@ defmodule Perf.MetricsCollector do
   use GenServer
 
   def send_metrics(results, step, concurrency) do
-    partial = PartialResult.calculate(results)
+    partial = PartialResult.calculate(results, keep_responses: Application.get_env(:perf_analyzer, :jmeter_report, true))
     GenServer.call({:global, __MODULE__}, {:results, partial, step, concurrency})
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,9 @@ defmodule PerfAnalyzer.MixProject do
       escript: [
         main_module: Cli.CommandLine
       ],
+      test_coverage: [
+        summary: [threshold: 34] # TODO: increase project coverage
+      ],
       deps: deps()
     ]
   end


### PR DESCRIPTION
Add property to disable the jmeter report generation, in some cases this consumes a lots of memory and the performance test crashes, this is a temporary fix, to disable it when not needed. 