### PR TITLE
header processing improvement and update report_use_case test

### DIFF
--- a/lib/domain/model/request_result.ex
+++ b/lib/domain/model/request_result.ex
@@ -71,13 +71,16 @@ defmodule DistributedPerformanceAnalyzer.Domain.Model.RequestResult do
             received_bytes: "",
             content_type: ""
 
-  @spec new(String.t(), String.t(), String.t(), integer(), integer()) :: RequestResult.t()
-  def new(label, thread_name, url, sent_bytes, connect) do
+  @spec new(String.t(), String.t(), String.t(), integer(), integer(), integer()) ::
+          RequestResult.t()
+  def new(label, thread_name, url, sent_bytes, connect, concurrency) do
     %__MODULE__{
       start: :erlang.monotonic_time(:millisecond),
       time_stamp: System.os_time(:millisecond),
       label: label,
       thread_name: thread_name,
+      grp_threads: concurrency,
+      all_threads: concurrency,
       url: url,
       sent_bytes: sent_bytes,
       connect: connect

--- a/lib/domain/model/request_result.ex
+++ b/lib/domain/model/request_result.ex
@@ -23,7 +23,8 @@ defmodule DistributedPerformanceAnalyzer.Domain.Model.RequestResult do
     "latency",
     "idle_time",
     "connect",
-    "response_headers"
+    "received_bytes",
+    "content_type"
   ]
 
   @type t :: %__MODULE__{
@@ -45,7 +46,8 @@ defmodule DistributedPerformanceAnalyzer.Domain.Model.RequestResult do
           latency: float(),
           idle_time: float(),
           connect: integer(),
-          response_headers: list()
+          received_bytes: String.t(),
+          content_type: String.t()
         }
 
   defstruct start: 0,
@@ -66,7 +68,8 @@ defmodule DistributedPerformanceAnalyzer.Domain.Model.RequestResult do
             latency: 0,
             idle_time: 0,
             connect: 0,
-            response_headers: []
+            received_bytes: "",
+            content_type: ""
 
   @spec new(String.t(), String.t(), String.t(), integer(), integer()) :: RequestResult.t()
   def new(label, thread_name, url, sent_bytes, connect) do

--- a/lib/domain/use_cases/connection_process_use_case.ex
+++ b/lib/domain/use_cases/connection_process_use_case.ex
@@ -19,11 +19,11 @@ defmodule DistributedPerformanceAnalyzer.Domain.UseCase.ConnectionProcessUseCase
     {:ok, pid}
   end
 
-  def request(pid, method, path, headers, body) do
+  def request(pid, method, path, headers, body, concurrency) do
     Logger.debug(%{method: method, path: path, headers: headers, body: body})
 
     :timer.tc(fn ->
-      GenServer.call(pid, {:request, method, path, headers, body}, 15_000)
+      GenServer.call(pid, {:request, method, path, headers, body, concurrency}, 15_000)
     end)
   end
 
@@ -52,14 +52,15 @@ defmodule DistributedPerformanceAnalyzer.Domain.UseCase.ConnectionProcessUseCase
   end
 
   @impl true
-  def handle_call({:request, method, path, headers, body}, from, state) do
+  def handle_call({:request, method, path, headers, body, concurrency}, from, state) do
     response =
       RequestResult.new(
         "sample",
         "#{inspect(self())}",
         get_endpoint(state.conn, path, method),
         String.length(body),
-        state.conn_time
+        state.conn_time,
+        concurrency
       )
 
     # IO.puts "Making Request!"

--- a/lib/domain/use_cases/connection_process_use_case.ex
+++ b/lib/domain/use_cases/connection_process_use_case.ex
@@ -9,6 +9,7 @@ defmodule DistributedPerformanceAnalyzer.Domain.UseCase.ConnectionProcessUseCase
   require Logger
   alias DistributedPerformanceAnalyzer.Domain.Model.{ConnectionProcess, RequestResult}
   alias DistributedPerformanceAnalyzer.Domain.UseCase.RequestResultUseCase
+  alias DistributedPerformanceAnalyzer.Utils.DataTypeUtils
 
   # defstruct [:conn, :params, :conn_time, request: %{}]
 
@@ -181,7 +182,12 @@ defmodule DistributedPerformanceAnalyzer.Domain.UseCase.ConnectionProcessUseCase
          }
        ) do
     # IO.puts("Done request!")
-    final_result = RequestResultUseCase.complete(response, status, body, headers, latency)
+    received_bytes = DataTypeUtils.extract_header(headers, "content-length")
+    content_type = DataTypeUtils.extract_header(headers, "content-type")
+
+    final_result =
+      RequestResultUseCase.complete(response, status, body, received_bytes, content_type, latency)
+
     GenServer.reply(from, {status_for(status), final_result})
     %{state | request: %{}}
   end

--- a/lib/domain/use_cases/metrics_analyzer_use_case.ex
+++ b/lib/domain/use_cases/metrics_analyzer_use_case.ex
@@ -78,18 +78,4 @@ defmodule DistributedPerformanceAnalyzer.Domain.UseCase.MetricsAnalyzerUseCase d
   def success?(_status), do: false
   def with_failure(status, _body) when status >= 200 and status < 400, do: nil
   def with_failure(_status, body), do: body
-
-  def data_type(headers) do
-    case Enum.find(headers, "TEXT", fn {type, _value} -> type == "content-type" end) do
-      {_header, value} -> value
-      default -> default
-    end
-  end
-
-  def bytes(headers) do
-    case Enum.find(headers, "TEXT", fn {type, _value} -> type == "content-length" end) do
-      {_header, value} -> value
-      default -> default
-    end
-  end
 end

--- a/lib/domain/use_cases/metrics_analyzer_use_case.ex
+++ b/lib/domain/use_cases/metrics_analyzer_use_case.ex
@@ -5,8 +5,8 @@ defmodule DistributedPerformanceAnalyzer.Domain.UseCase.MetricsAnalyzerUseCase d
   use GenServer
   alias DistributedPerformanceAnalyzer.Domain.Model.ExecutionModel
   alias DistributedPerformanceAnalyzer.Domain.UseCase.MetricsCollectorUseCase
-  alias DistributedPerformanceAnalyzer.Utils.Statistics
   alias DistributedPerformanceAnalyzer.Domain.UseCase.Reports.ReportUseCase
+  alias DistributedPerformanceAnalyzer.Utils.{Statistics, DataTypeUtils}
 
   def compute_metrics do
     GenServer.cast(__MODULE__, :compute)
@@ -57,6 +57,8 @@ defmodule DistributedPerformanceAnalyzer.Domain.UseCase.MetricsAnalyzerUseCase d
         end
       )
 
+    IO.inspect(curve)
+
     total_success_count =
       Enum.reduce(steps, 0, fn step, acc -> Map.get(metrics, step).success_count + acc end)
 
@@ -77,5 +79,5 @@ defmodule DistributedPerformanceAnalyzer.Domain.UseCase.MetricsAnalyzerUseCase d
   def success?(status) when status >= 200 and status < 400, do: true
   def success?(_status), do: false
   def with_failure(status, _body) when status >= 200 and status < 400, do: nil
-  def with_failure(_status, body), do: body
+  def with_failure(_status, body), do: DataTypeUtils.format_failure(body)
 end

--- a/lib/domain/use_cases/metrics_analyzer_use_case.ex
+++ b/lib/domain/use_cases/metrics_analyzer_use_case.ex
@@ -57,8 +57,6 @@ defmodule DistributedPerformanceAnalyzer.Domain.UseCase.MetricsAnalyzerUseCase d
         end
       )
 
-    IO.inspect(curve)
-
     total_success_count =
       Enum.reduce(steps, 0, fn step, acc -> Map.get(metrics, step).success_count + acc end)
 

--- a/lib/domain/use_cases/reports/report_use_case.ex
+++ b/lib/domain/use_cases/reports/report_use_case.ex
@@ -110,9 +110,10 @@ defmodule DistributedPerformanceAnalyzer.Domain.UseCase.Reports.ReportUseCase do
            latency: latency,
            idle_time: idle_time,
            connect: connect,
-           response_headers: headers
+           received_bytes: received_bytes,
+           content_type: content_type
          } ->
-        "#{time_stamp},#{elapsed},#{label},#{response_code},#{MetricsAnalyzerUseCase.response_for_code(response_code)},#{thread_name},#{MetricsAnalyzerUseCase.data_type(headers)},#{MetricsAnalyzerUseCase.success?(response_code)},#{MetricsAnalyzerUseCase.with_failure(response_code, failure_message)},#{MetricsAnalyzerUseCase.bytes(headers)},#{sent_bytes},#{grp_threads},#{all_threads},#{url},#{latency},#{idle_time},#{connect}"
+        "#{time_stamp},#{elapsed},#{label},#{response_code},#{MetricsAnalyzerUseCase.response_for_code(response_code)},#{thread_name},#{content_type},#{MetricsAnalyzerUseCase.success?(response_code)},#{MetricsAnalyzerUseCase.with_failure(response_code, failure_message)},#{received_bytes},#{sent_bytes},#{grp_threads},#{all_threads},#{url},#{latency},#{idle_time},#{connect}"
       end
     )
   end

--- a/lib/domain/use_cases/request_result_use_case.ex
+++ b/lib/domain/use_cases/request_result_use_case.ex
@@ -9,7 +9,8 @@ defmodule DistributedPerformanceAnalyzer.Domain.UseCase.RequestResultUseCase do
         %RequestResult{start: start} = initial,
         response_code,
         body,
-        response_headers,
+        received_bytes,
+        content_type,
         latency
       ) do
     elapsed = :erlang.monotonic_time(:milli_seconds) - start
@@ -20,7 +21,8 @@ defmodule DistributedPerformanceAnalyzer.Domain.UseCase.RequestResultUseCase do
         latency: latency - start,
         response_code: response_code,
         failure_message: body,
-        response_headers: response_headers
+        received_bytes: received_bytes,
+        content_type: content_type
     }
   end
 end

--- a/lib/utils/data_type_utils.ex
+++ b/lib/utils/data_type_utils.ex
@@ -78,4 +78,8 @@ defmodule DistributedPerformanceAnalyzer.Utils.DataTypeUtils do
 
   def duration_time(start),
     do: (System.monotonic_time() - start) |> monotonic_time_to_milliseconds()
+
+  def format_failure(body) do
+    String.replace(body, ",", ".")
+  end
 end

--- a/lib/utils/data_type_utils.ex
+++ b/lib/utils/data_type_utils.ex
@@ -23,8 +23,8 @@ defmodule DistributedPerformanceAnalyzer.Utils.DataTypeUtils do
 
   def extract_header(headers, name) when is_list(headers) do
     case extract_header!(headers, name) do
-      {:ok, value} when value != nil -> {:ok, value}
-      _ -> {:error, :not_found}
+      {:ok, value} -> value
+      default -> default
     end
   end
 

--- a/test/domain/use_cases/report/reports_use_case_test.exs
+++ b/test/domain/use_cases/report/reports_use_case_test.exs
@@ -12,7 +12,6 @@ defmodule DistributedPerformanceAnalyzer.Test.Domain.UseCase.Reports.ReportsUseC
                 :distributed_performance_analyzer,
                 :report_csv
               )
-
   @data [
     {1, 6, 113, 102, 0},
     {2, 19, 101, 102, 0},
@@ -49,12 +48,8 @@ defmodule DistributedPerformanceAnalyzer.Test.Domain.UseCase.Reports.ReportsUseC
             latency: 102,
             idle_time: 0,
             connect: 0,
-            response_headers: [
-              {"cache-control", "max-age=0, private, must-revalidate"},
-              {"content-length", "25"},
-              {"date", "Fri, 02 Jun 2023 01:11:20 GMT"},
-              {"server", "Cowboy"}
-            ]
+            received_bytes: "25",
+            content_type: "application/json"
           }
         ],
         p90: 102,
@@ -126,12 +121,8 @@ defmodule DistributedPerformanceAnalyzer.Test.Domain.UseCase.Reports.ReportsUseC
             latency: 102,
             idle_time: 0,
             connect: 0,
-            response_headers: [
-              {"cache-control", "max-age=0, private, must-revalidate"},
-              {"content-length", "25"},
-              {"date", "Fri, 02 Jun 2023 01:11:20 GMT"},
-              {"server", "Cowboy"}
-            ]
+            received_bytes: "25",
+            content_type: "application/json"
           }
         ],
         p90: 102,
@@ -208,12 +199,8 @@ defmodule DistributedPerformanceAnalyzer.Test.Domain.UseCase.Reports.ReportsUseC
         latency: 102,
         idle_time: 0,
         connect: 0,
-        response_headers: [
-          {"cache-control", "max-age=0, private, must-revalidate"},
-          {"content-length", "25"},
-          {"date", "Fri, 02 Jun 2023 01:11:20 GMT"},
-          {"server", "Cowboy"}
-        ]
+        received_bytes: "25",
+        content_type: "application/json"
       }
     ]
 
@@ -241,9 +228,10 @@ defmodule DistributedPerformanceAnalyzer.Test.Domain.UseCase.Reports.ReportsUseC
                     latency: latency,
                     idle_time: idle_time,
                     connect: connect,
-                    response_headers: headers
+                    received_bytes: received_bytes,
+                    content_type: content_type
                   } ->
-                 "#{time_stamp},#{elapsed},#{label},#{response_code},#{MetricsAnalyzerUseCase.response_for_code(response_code)},#{thread_name},#{MetricsAnalyzerUseCase.data_type(headers)},#{MetricsAnalyzerUseCase.success?(response_code)},#{MetricsAnalyzerUseCase.with_failure(response_code, failure_message)},#{MetricsAnalyzerUseCase.bytes(headers)},#{sent_bytes},#{grp_threads},#{all_threads},#{url},#{latency},#{idle_time},#{connect}"
+                 "#{time_stamp},#{elapsed},#{label},#{response_code},#{MetricsAnalyzerUseCase.response_for_code(response_code)},#{thread_name},#{content_type},#{MetricsAnalyzerUseCase.success?(response_code)},#{MetricsAnalyzerUseCase.with_failure(response_code, failure_message)},#{received_bytes},#{sent_bytes},#{grp_threads},#{all_threads},#{url},#{latency},#{idle_time},#{connect}"
                end
              )
   end


### PR DESCRIPTION
Redefine headers processing.

-It makes use of the extract_headers function of the data_type_utils module in the utils folder.
-Modify the generate jmeter report.
-update report_use_case test.
-Redefine request_result model and complete function in use_case.